### PR TITLE
Add sha256 signature support(with fallback to sha).

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## master
 
+- Support SHA256 signatures(with a fallback to SHA) in `ReceiptDecoder.Verifier`
 - Require Elixir 1.13.
 
 ## v0.5.0

--- a/lib/receipt_decoder/verifier/verifier.ex
+++ b/lib/receipt_decoder/verifier/verifier.ex
@@ -118,7 +118,9 @@ defmodule ReceiptDecoder.Verifier do
     public_key = extract_public_key(itunes_cert)
 
     with {:ok, payload} <- Extractor.extract_payload(receipt),
-         true <- :public_key.verify(payload, :sha, signature, public_key) do
+         true <-
+           :public_key.verify(payload, :sha256, signature, public_key) or
+             :public_key.verify(payload, :sha, signature, public_key) do
       :ok
     else
       false ->


### PR DESCRIPTION
Apple docs state that

August 14, 2023. Receipts in new apps and app updates submitted to the App Store, as well as all apps in sandbox, will be signed with the SHA‑256 intermediate certificate.

https://developer.apple.com/news/?id=smofnyhj

I've tested the changes with a few receipts from our app, it seems to be working just fine.